### PR TITLE
feat: add ChatOps workflows and docs for universal agent

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+docs:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.md']
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/workflows/**']
+content:
+  - changed-files:
+      - any-glob-to-any-file: ['content/**']

--- a/.github/workflows/go_kill.yml
+++ b/.github/workflows/go_kill.yml
@@ -1,0 +1,25 @@
+name: go_kill
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  handle:
+    if: >
+      github.event.issue.pull_request != null &&
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
+      (contains(github.event.comment.body, '/go') || contains(github.event.comment.body, '/kill'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Go or kill
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if echo "${{ github.event.comment.body }}" | grep -q '/go'; then
+            gh pr ready ${{ github.event.issue.number }} -R $GITHUB_REPOSITORY
+          fi
+          if echo "${{ github.event.comment.body }}" | grep -q '/kill'; then
+            gh pr close ${{ github.event.issue.number }} -R $GITHUB_REPOSITORY --delete-branch
+          fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: labeler
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,11 @@
+name: pr-gate
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+permissions:
+  contents: read
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo pr-gate

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,34 @@
+name: site
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: write
+jobs:
+  build:
+    if: >
+      github.event.issue.pull_request != null &&
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
+      contains(github.event.comment.body, '/site')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.issue.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+      - run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: Build site
+        run: |
+          mkdir -p docs/site
+          for f in content/*.md; do
+            b=$(basename "$f" .md)
+            pandoc "$f" -o "docs/site/$b.html"
+          done
+      - name: Commit site
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add docs/site
+          git commit -m "chore: update site" || echo "no changes"
+          git push

--- a/.github/workflows/slides.yml
+++ b/.github/workflows/slides.yml
@@ -1,0 +1,27 @@
+name: slides
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  actions: write
+jobs:
+  build:
+    if: >
+      github.event.issue.pull_request != null &&
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
+      contains(github.event.comment.body, '/slides')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update && sudo apt-get install -y pandoc wkhtmltopdf
+      - name: Build slides
+        run: |
+          pandoc PRFAQ_1pager.md -t revealjs -s -o slides.html
+          wkhtmltopdf slides.html slides.pdf
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slides
+          path: |
+            slides.pdf
+            slides.html

--- a/.github/workflows/thumb.yml
+++ b/.github/workflows/thumb.yml
@@ -1,0 +1,44 @@
+name: thumb
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: write
+jobs:
+  build:
+    if: >
+      github.event.issue.pull_request != null &&
+      (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') &&
+      contains(github.event.comment.body, '/thumb')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.issue.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.issue.pull_request.head.ref }}
+      - run: sudo apt-get update && sudo apt-get install -y imagemagick
+      - name: Generate images
+        run: |
+          mkdir -p public/og public/thumb
+          for f in content/*.md; do
+            b=$(basename "$f" .md)
+            title=$(head -n 1 "$f" | sed 's/^# *//')
+            convert -size 1200x630 -background '#ffffff' -fill '#000000' -gravity center -font DejaVu-Sans -pointsize 72 caption:"$title" "public/og/$b.png"
+            for s in 256 512 1024; do
+              convert "public/og/$b.png" -resize ${s}x${s} "public/thumb/$b-${s}.webp"
+            done
+          done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: thumbs
+          path: |
+            public/og
+            public/thumb
+      - name: Commit images
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add public/og public/thumb
+          git commit -m "chore: update thumbnails" || echo "no changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ Runbook documentation is available in [docs/agent_runbook_v1.md](docs/agent_runb
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## クイックスタート
+1. PRで `/slides` とコメントすると、`PRFAQ_1pager.md` から slides.pdf と slides.html が生成されます。
+2. `/site` で `content/` 内の Markdown を `docs/site/` に静的HTMLとして公開します。
+3. `/thumb` で `content/` 内の Markdown から OG画像と各解像度のサムネイルを作成します。
+
+### トラブルシューティング
+| 問題 | 解決策 |
+| --- | --- |
+| `pandoc: command not found` | `sudo apt-get install -y pandoc` |
+| `convert: command not found` | `sudo apt-get install -y imagemagick` |
+| PRを作成できない | リポジトリ設定で「Allow GitHub Actions to create and approve pull requests」と「Read and write permissions」を有効にする |
+
+### DIFF-5
+レビューを容易にするため、1つのPRでの変更は5行以内を目指してください。

--- a/content/hello.md
+++ b/content/hello.md
@@ -1,0 +1,3 @@
+# Hello
+
+This is sample content.


### PR DESCRIPTION
## Summary
- 必須チェック用の pr-gate ワークフローを追加
- /slides /site /thumb /go /kill の ChatOps ワークフローを実装
- ラベル自動付与のため labeler ワークフローと設定を追加
- サンプルコンテンツと README を追加し、日本語でクイックスタートとトラブルシューティングを記載
- LaTeX 不要で slides.pdf / slides.html を生成

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a371398d988329bbec308274fa50dc